### PR TITLE
exclude missing profiles from stats

### DIFF
--- a/src/AdminPortalModule.php
+++ b/src/AdminPortalModule.php
@@ -226,9 +226,14 @@ class AdminPortalModule implements ServiceModuleInterface
                 $profileList = $this->serverClient->getRequireArray('profile_list');
 
                 $idNameMapping = [];
+                $profiles = [];
                 foreach ($profileList as $profileId => $profileData) {
-                    $idNameMapping[$profileId] = $profileData['displayName'];
+                    if (array_key_exists($profileId, $stats['profiles'])) {
+                        $idNameMapping[$profileId] = $profileData['displayName'];
+                        $profiles[$profileId] = $stats['profiles'][$profileId];
+                    }
                 }
+                $stats['profiles'] = $profiles;
 
                 return new HtmlResponse(
                     $this->tpl->render(


### PR DESCRIPTION
When viewing the Stats page just after renaming a profile, it will fail with `Key "internet" for array with keys "uninett" does not exist in "vpnStats.twig" at line 41.`. This is because the list of statistics doesn't match the list of actual profiles.

This PR excludes profiles from `$stats['profiles']` that are missing from `$profileList`.